### PR TITLE
Added support for tier 4 breadcrumbs.

### DIFF
--- a/docs/pages/content-design/principles/be-concise.md
+++ b/docs/pages/content-design/principles/be-concise.md
@@ -1,6 +1,8 @@
 ---
 title: Be concise
 parentid: Content design
+subparentid: Content design principles
+subparentidlink: /content-design/principles/
 description: Simple writing supports equal outcomes.
 headerlabel: Standards and principles
 headericon: star

--- a/docs/pages/content-design/principles/build-accessibility-from-start.md
+++ b/docs/pages/content-design/principles/build-accessibility-from-start.md
@@ -1,6 +1,8 @@
 ---
 title: Build in accessibility from the start
 parentid: Content design
+subparentid: Content design principles
+subparentidlink: /content-design/principles/
 description: Accessibility goes beyond the technical components of a website. It’s about including everyone who has a right to information.
 headerlabel: Standards and principles
 headericon: star

--- a/docs/pages/content-design/principles/focus-on-user-needs-services.md
+++ b/docs/pages/content-design/principles/focus-on-user-needs-services.md
@@ -1,6 +1,8 @@
 ---
 title: Focus on user needs and services
 parentid: Content design
+subparentid: Content design principles
+subparentidlink: /content-design/principles/
 description: Give people what they need and direct them to services.
 headerlabel: Standards and principles
 headericon: star

--- a/docs/pages/content-design/principles/meet-your-audience-where-they-are.md
+++ b/docs/pages/content-design/principles/meet-your-audience-where-they-are.md
@@ -1,6 +1,8 @@
 ---
 title: Meet your audience where they are
 parentid: Content design
+subparentid: Content design principles
+subparentidlink: /content-design/principles/
 description: Knowing who they are and what they need helps you design for them.
 headerlabel: Standards and principles
 headericon: star

--- a/docs/pages/content-design/principles/organize-content-strategically.md
+++ b/docs/pages/content-design/principles/organize-content-strategically.md
@@ -1,6 +1,8 @@
 ---
 title: Organize content strategically
 parentid: Content design
+subparentid: Content design principles
+subparentidlink: /content-design/principles/
 description: Well-organized content helps readers find what they’re looking for.
 headerlabel: Standards and principles
 headericon: star

--- a/docs/pages/content-design/principles/write-in-plain-language.md
+++ b/docs/pages/content-design/principles/write-in-plain-language.md
@@ -1,6 +1,8 @@
 ---
 title: Write in plain language
 parentid: Content design
+subparentid: Content design principles
+subparentidlink: /content-design/principles/
 description: Do the hard work to make content simple for people to understand.
 headerlabel: Standards and principles
 headericon: star

--- a/docs/pages/content-design/principles/write-with-conversational-official-voice.md
+++ b/docs/pages/content-design/principles/write-with-conversational-official-voice.md
@@ -1,6 +1,8 @@
 ---
 title: Write with a conversational and official voice
 parentid: Content design
+subparentid: Content design principles
+subparentidlink: /content-design/principles/
 description: Give reliable information with confidence.
 headerlabel: Standards and principles
 headericon: star

--- a/docs/site/_includes/layouts/page.njk
+++ b/docs/site/_includes/layouts/page.njk
@@ -9,6 +9,15 @@
       <span class="crumb separator">/</span>
       <span class="crumb">{{ parentid | safe }}</span>
     {% endif %}
+    {% if subparentid %}
+      {% if subparentidlink %}
+        <span class="crumb separator">/</span>
+        <a class="crumb" href="{{ subparentidlink }}" title="{{ subparentid | safe }}">{{ subparentid | safe }}</a>
+      {% else %}
+        <span class="crumb separator">/</span>
+        <span class="crumb">{{ subparentid | safe }}</span>
+      {% endif %}
+    {% endif %}
     <span class="crumb separator">/</span>
     <span class="crumb current">{{ title | safe }}</span>
   </div>

--- a/docs/site/_includes/layouts/single-column-wide.html
+++ b/docs/site/_includes/layouts/single-column-wide.html
@@ -9,6 +9,15 @@
       <span class="crumb separator">/</span>
       <span class="crumb">{{ parentid | safe }}</span>
     {% endif %}
+    {% if subparentid %}
+      {% if subparentidlink %}
+        <span class="crumb separator">/</span>
+        <a class="crumb" href="{{ subparentidlink }}" title="{{ subparentid | safe }}">{{ subparentid | safe }}</a>
+      {% else %}
+        <span class="crumb separator">/</span>
+        <span class="crumb">{{ subparentid | safe }}</span>
+      {% endif %}
+    {% endif %}
     <span class="crumb separator">/</span>
     <span class="crumb current">{{ title | safe }}</span>
   </div>

--- a/docs/site/_includes/layouts/single-column.njk
+++ b/docs/site/_includes/layouts/single-column.njk
@@ -9,6 +9,15 @@
       <span class="crumb separator">/</span>
       <span class="crumb">{{ parentid | safe }}</span>
     {% endif %}
+    {% if subparentid %}
+      {% if subparentidlink %}
+        <span class="crumb separator">/</span>
+        <a class="crumb" href="{{ subparentidlink }}" title="{{ subparentid | safe }}">{{ subparentid | safe }}</a>
+      {% else %}
+        <span class="crumb separator">/</span>
+        <span class="crumb">{{ subparentid | safe }}</span>
+      {% endif %}
+    {% endif %}
     <span class="crumb separator">/</span>
     <span class="crumb current">{{ title | safe }}</span>
   </div>


### PR DESCRIPTION
Added support for 4 tiered breadcrumbs, used in the "Content principles" section of the site.

Before:
![CleanShot 2024-03-12 at 15 40 47](https://github.com/cagov/hub.innovation.ca.gov/assets/287977/4f7da83a-cff2-4c66-8bcb-bfc3a19417c2)


After:
![CleanShot 2024-03-12 at 15 40 57](https://github.com/cagov/hub.innovation.ca.gov/assets/287977/61052a63-b11e-4c56-87f8-93289b8f0d02)

This was implemented by adding two new page headers: subparentid and subparentidlink.  
* subparentid should be a text label that appears in the breadcrumb list
* subparentidlink is an optional relative URL that provides navigation to the subparent page
