### PR TITLE
Introduction to plain language for the public sector online, self-paced course launch

### DIFF
--- a/docs/pages/content-design/introduction-plain-language-public-sector.md
+++ b/docs/pages/content-design/introduction-plain-language-public-sector.md
@@ -1,0 +1,21 @@
+---
+title: Introduction to plain language for the public sector
+parentid: Content design
+description: An introduction to plain language for State of California staff
+layout: single-column
+keywords: 
+headerlabel: Training
+headericon: ribbon
+---
+
+<p class="text-lead">This online, self-paced course gives you an introduction to plain language.</p>
+
+You’ll learn:
+
+* The principles of plain language
+* The benefits and equity of plain language
+* How to create products and services that align with California’s plain language standard
+
+The course includes opportunities to practice writing in plain language. You will be able to start using the skills you learn immediately.
+
+[Sign up for the course on CalLearns](https://calhr.geniussis.com/Registration.aspx?AID=4210). You need a CalLearns account to register for the training.

--- a/docs/site/_includes/featured-content.njk
+++ b/docs/site/_includes/featured-content.njk
@@ -22,6 +22,15 @@
               </div>
             </a>
 
+          <a class="tile-link" href="/content-design/introduction-plain-language-public-sector/">
+            <div class="content-tile">
+              <div class="content-tile-header header-ribbon"><span class="title-card-header-label">Training</span></div>
+              <div class="content-tile-title">Introduction to plain language for the public sector</div>
+              <p>An online, self-paced course introducing plain language for State of California staff
+              </p>
+            </div>
+          </a>
+
             <a class="tile-link" href="/content-design/plain-language-checklist/">
               <div class="content-tile">
                 <div class="content-tile-header header-book"><span class="title-card-header-label">Guides and playbooks</span></div>

--- a/docs/site/_includes/site-navigation.njk
+++ b/docs/site/_includes/site-navigation.njk
@@ -78,6 +78,7 @@
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/principles/" tabindex="-1">Content design principles</a>              
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/plain-language-equity-standard/" tabindex="-1">Plain language equity standard</a>
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/odi-style-guide/" tabindex="-1">ODI's style guide</a>
+              <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/introduction-plain-language-public-sector/" tabindex="-1">Introduction to plain language for the public sector</a>
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/plain-language-checklist/" tabindex="-1">Plain language checklist</a>
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/recommended-reading/" tabindex="-1">Recommended reading: content design</a>
             </div>

--- a/docs/site/homepage.njk
+++ b/docs/site/homepage.njk
@@ -51,6 +51,15 @@ layout: homepage-layout
             </p>
           </div></a>
 
+          <a class="tile-link" href="/content-design/introduction-plain-language-public-sector/">
+            <div class="content-tile">
+              <div class="content-tile-header header-ribbon"><span class="title-card-header-label">Training</span></div>
+              <div class="content-tile-title">Introduction to plain language for the public sector</div>
+              <p>An online, self-paced course introducing plain language for State of California staff
+              </p>
+            </div>
+          </a>
+
           <a class="tile-link" href="/content-design/odi-style-guide/">
             <div class="content-tile">
             <div class="content-tile-header header-book"><span class="title-card-header-label">Guides and playbooks</span></div>


### PR DESCRIPTION
- Added new _Introduction to plain language for the public sector_ page
- Updated _Plain language equity toolkit_ and _Content design_ sections on homepage
- Updated site navigation

Hold publishing until July 1 and CalAcademy approves.