### PR TITLE
Oct 23 plain language 101b course title

### DIFF
--- a/docs/pages/content-design/building-better-services-plain-language.md
+++ b/docs/pages/content-design/building-better-services-plain-language.md
@@ -1,5 +1,5 @@
 ---
-title: More plain language for the public sector
+title: Building better services with plain language
 parentid: Content design
 description: An intermediate course on plain language for State of California staff
 keywords: 
@@ -29,10 +29,6 @@ To take the course, you need:
 
 ### Dates
 
-* [September 10, 2024](https://calhr.geniussis.com/Registration.aspx?AID=4239)
-* [September 26, 2024](https://calhr.geniussis.com/Registration.aspx?AID=4240)
-* [October 10, 2024](https://calhr.geniussis.com/Registration.aspx?AID=4241)
-* [October 22, 2024](https://calhr.geniussis.com/Registration.aspx?AID=4242)
 * [November 7, 2024](https://calhr.geniussis.com/Registration.aspx?AID=4243)
 * [November 21, 2024](https://calhr.geniussis.com/Registration.aspx?AID=4244)
 * [December 5, 2024](https://calhr.geniussis.com/Registration.aspx?AID=4245)

--- a/docs/site/_includes/featured-content.njk
+++ b/docs/site/_includes/featured-content.njk
@@ -31,10 +31,10 @@
             </div>
           </a>
 
-          <a class="tile-link" href="/content-design/more-plain-language-public-sector/">
+          <a class="tile-link" href="/content-design/building-better-services-plain-language/">
             <div class="content-tile">
               <div class="content-tile-header header-ribbon"><span class="title-card-header-label">Training</span></div>
-              <div class="content-tile-title">More plain language for the public sector</div>
+              <div class="content-tile-title">Building better services with plain language</div>
               <p>A 90-minute course that covers intermediate plain language skills and methods
               </p>
             </div>

--- a/docs/site/_includes/site-navigation.njk
+++ b/docs/site/_includes/site-navigation.njk
@@ -79,7 +79,7 @@
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/plain-language-equity-standard/" tabindex="-1">Plain language equity standard</a>
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/odi-style-guide/" tabindex="-1">ODI's style guide</a>
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/introduction-plain-language-public-sector/" tabindex="-1">Introduction to plain language for the public sector</a>
-              <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/more-plain-language-public-sector/" tabindex="-1">More plain language for the public sector</a>
+              <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/building-better-services-plain-language/" tabindex="-1">Building better services with plain language</a>
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/plain-language-checklist/" tabindex="-1">Plain language checklist</a>
               <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/content-design/recommended-reading/" tabindex="-1">Recommended reading: content design</a>
             </div>

--- a/docs/site/homepage.njk
+++ b/docs/site/homepage.njk
@@ -61,10 +61,10 @@ layout: homepage-layout
           </a>
 
 
-          <a class="tile-link" href="/content-design/more-plain-language-public-sector/">
+          <a class="tile-link" href="/content-design/building-better-services-plain-language/">
             <div class="content-tile">
               <div class="content-tile-header header-ribbon"><span class="title-card-header-label">Training</span></div>
-              <div class="content-tile-title">More plain language for the public sector</div>
+              <div class="content-tile-title">Building better services with plain language</div>
               <p>A 90-minute course that covers intermediate plain language skills and methods
               </p>
             </div>


### PR DESCRIPTION
- Updated title of _More plain language for the public sector_ to _Building better services with plain language_
- Removed course sessions that have passed
- Updated homepage references and links