### PR TITLE
Fixed markup issue on home page that broke layout.

### DIFF
--- a/docs/site/homepage.njk
+++ b/docs/site/homepage.njk
@@ -101,6 +101,7 @@ layout: homepage-layout
         <p>Use information to deliver better decisions, services, and outcomes</p>
 
         <div class="content-grid-wrapper">
+
           <a class="tile-link" href="/data/building-housing-intelligence/">
           <div class="content-tile">
             <div class="content-tile-header header-paper"><span class="title-card-header-label">Papers</span></div>
@@ -109,7 +110,6 @@ layout: homepage-layout
             </p>
           </div></a>
 
-        <div class="content-grid-wrapper">
           <a class="tile-link" href="/data/enabling-analysis-californias-hiring-recruitment-data/">
           <div class="content-tile">
             <div class="content-tile-header header-paper"><span class="title-card-header-label">Papers</span></div>
@@ -125,6 +125,7 @@ layout: homepage-layout
             <p>How ODI forecasted the impact of drought on community water systems
             </p>
           </div></a>
+        </div>
       </div>
       <br clear="all"/>
       <hr class="homepage-divider" />


### PR DESCRIPTION
There was a cut & paste error on the homepage that broke the styling.  This fixes it.

BEFORE:

![image](https://github.com/user-attachments/assets/9f9a1585-ddf1-4f3f-b17d-79eaba92184a)

AFTER:

![CleanShot 2024-12-17 at 09 41 53](https://github.com/user-attachments/assets/2d655caa-8c85-4fc7-a175-aba285ed0e35)
