### PR TITLE
Addressing line break issue.

### DIFF
--- a/docs/pages/data/building-housing-intelligence.md
+++ b/docs/pages/data/building-housing-intelligence.md
@@ -36,9 +36,8 @@ These questions must be answered to build rapidly and responsibly.
 
 Housing production data is reported to HCD by 539 jurisdictions (cities and counties) across the state. ODI partnered with HCD to build a tool called *Homestead* to mine, analyze, and visualize that data so HCD staff can have in-depth, granular knowledge on the state of housing production. The housing development process itself can be mired in review and with each jurisdiction comes a different set of project identifiers, local procedures, and reporting practices.
 
-<img src="/papers/madani-housing-1/bhi-fig-1.png" alt="539 jurisdictions are responsible for reporting on local building permitting and development milestones. Each office has its own reporting standards and practices. Median income levels and housing costs are initially measured on the county level. There are 58 counties in California. Data from local offices is ultimately analyzed by a single statewide housing department, the California Department of Housing and Community Development." />
+![539 jurisdictions are responsible for reporting on local building permitting and development milestones. Each office has its own reporting standards and practices. Median income levels and housing costs are initially measured on the county level. There are 58 counties in California. Data from local offices is ultimately analyzed by a single statewide housing department, the California Department of Housing and Community Development.](/papers/madani-housing-1/bhi-fig-1.png)
 <b>Figure 1.</b> Both jurisdictions and counties generate data related to housing development and cost of housing. All of which is funneled to one statewide agency: the Department of Housing & Community Development.
-
 
 Additionally, under AB 2653, HCD has 90 days to request corrections to reports from jurisdictions.
 

--- a/docs/pages/data/building-housing-intelligence.md
+++ b/docs/pages/data/building-housing-intelligence.md
@@ -52,8 +52,7 @@ One of the primary goals of ODI’s work was to help HCD detect outliers and idi
 3. **Local outlier factor:** Calculates a local anomaly score for data points based on the density of “neighbors” nearby on a graph, revealing anomalies within their local context.
 
 We coupled the Z-Scoring approach with text processing to flag anomalous values consistently. An anomalous value might include multi-unit buildings that were reportedly built in less than a week or multiple parcels bundled together as one record. The final dashboard will have an interface for HCD staff to filter for and export projects with anomalous values.
-
-<img src="/papers/madani-housing-1/bhi-fig-2.png" alt="An illustration of how Homestead identifies anomalies. It shows two stre ets of housing. One took 45 days-to-permit. Another took 48 days-to-permit. The next took 50-days-to-permit. Highlighted is a property that took 200 days-to-permit." />
+![An illustration of how Homestead identifies anomalies. It shows two stre ets of housing. One took 45 days-to-permit. Another took 48 days-to-permit. The next took 50-days-to-permit. Highlighted is a property that took 200 days-to-permit.](/papers/madani-housing-1/bhi-fig-2.png)
 <b>Figure 2.</b> Using development milestones like permit issuance and certificate of occupancy dates, we can flag developments with inordinately long timelines relative to comparable constructions.
 
 ### Geospatial analysis
@@ -63,8 +62,7 @@ One of the greatest challenges to making sense of housing data is the inconsiste
 1. **Geolocation functionality:** Map every project’s physical street address reported by jurisdictions (for example, 123 Main St. Los Angeles, CA 90720) to a latitude and longitude
 2. **Shape processing:** Ingest and simplify shape files that represent California’s protected zones
 3. **Spatial joining:** Map projects and protected zones to see which projects intersect with protected zones. Those that do not and meet SB 423 criteria are eligible for streamlining
-
-<img src="/papers/madani-housing-1/bhi-fig-3.png" alt="This example shows the same two streets with coordinates for some homes. Some homes are in a fire hazard zone." />
+![This example shows the same two streets with coordinates for some homes. Some homes are in a fire hazard zone.](/papers/madani-housing-1/bhi-fig-3.png)
 <b>Figure 3.</b> By mapping shape files representing sensitive geographic areas and project addresses, we can determine geographic eligibility for streamlining.
 
 ### Automation
@@ -72,8 +70,7 @@ One of the greatest challenges to making sense of housing data is the inconsiste
 Lastly, we wanted *Homestead* to automate tasks that would otherwise take up large swaths of time, chipping away at the 90-day deadline HCD has to request corrections to reports. Repeatedly analyzing affordability using spreadsheets is one such task. Previously, inputs would need to be fed to a macro-enabled Excel file that would calculate affordability on a one-off basis for each individual unit size and county. 
 
 ODI and HCD worked together to convert logic from the Excel file to code. Using the logic and inputs from various government datasets, we are able to calculate affordable rent for every county, unit type/size, and year. The result is a dataset that we can build upon to have reliable, up-to-date, and visible affordability metrics.
-
-<img src="/papers/madani-housing-1/bhi-fig-4.png" alt="An affordability dashboard. It shows a map of the state with Alameda, Humboldt, Kern, and Los Angeles counties highlights. Line graphs showing YOY rent growth and statewode YOY rent growth percentages. Details for 2013-2022 are beneath the graphs." />
+![An affordability dashboard. It shows a map of the state with Alameda, Humboldt, Kern, and Los Angeles counties highlights. Line graphs showing YOY rent growth and statewode YOY rent growth percentages. Details for 2013-2022 are beneath the graphs.](/papers/madani-housing-1/bhi-fig-4.png)
 <b>Figure 4.</b> A screenshot of the affordability dashboard with filter controls, county-level housing cost changes, year-over-year trends, and table of housing affordability calculations.
 
 ## Impact

--- a/docs/pages/data/building-housing-intelligence.md
+++ b/docs/pages/data/building-housing-intelligence.md
@@ -39,6 +39,7 @@ Housing production data is reported to HCD by 539 jurisdictions (cities and coun
 <img src="/papers/madani-housing-1/bhi-fig-1.png" alt="539 jurisdictions are responsible for reporting on local building permitting and development milestones. Each office has its own reporting standards and practices. Median income levels and housing costs are initially measured on the county level. There are 58 counties in California. Data from local offices is ultimately analyzed by a single statewide housing department, the California Department of Housing and Community Development." />
 <b>Figure 1.</b> Both jurisdictions and counties generate data related to housing development and cost of housing. All of which is funneled to one statewide agency: the Department of Housing & Community Development.
 
+
 Additionally, under AB 2653, HCD has 90 days to request corrections to reports from jurisdictions.
 
 Building a tool to process this data and guide HCD’s analysis requires an array of functionality to: process data, detect anomalies, analyze geospatial data, and automate rote analyses. This requires a Python script that outputs new datasets derived from raw housing data and a dashboard that’s accessible department-wide.

--- a/docs/pages/data/enabling-analysis-californias-hiring-recruitment-data.md
+++ b/docs/pages/data/enabling-analysis-californias-hiring-recruitment-data.md
@@ -53,7 +53,7 @@ We used Fivetran as a low-code tool for copying primary data from the ECOS syste
 
 Once the raw data tables are in Snowflake, we use the dbt framework for transforming the data into analysis-ready datasets. This involves combining, filtering, and aggregating data from over 700 tables. This is a complex process, but the framework allows us to manage the complexity by tracking data lineage and enabling collaborative, version controlled queries.
 
-<img src="/papers/rose-hr-1/eac-fig-1.png" alt="Diagram of toolchains that make up the data pipeline" />
+![Diagram of toolchains that make up the data pipeline](/papers/rose-hr-1/eac-fig-1.png)
 
 The data pipeline built using the above toolchain runs daily (at least), ensuring that everyone using the data is acting on the latest version.
 
@@ -70,7 +70,7 @@ We worked with CalHR staff to host code in GitHub for the ECOS analysis project,
 5. A history of how the project has evolved, allowing for easy rollbacks and auditing
 6. Issue tracking to allow for questions, bug reports, and strategic discussions about the code
 
-<img src="/papers/rose-hr-1/eac-fig-2.png" alt="GitHub issue for FMD Questions on ECOS data. It includes a problem summary, record of work, and follow-up comments." />
+![GitHub issue for FMD Questions on ECOS data. It includes a problem summary, record of work, and follow-up comments.](/papers/rose-hr-1/eac-fig-2.png)
 
 ### Reporting: enabling advanced analytics and discovery
 
@@ -78,7 +78,7 @@ The ultimate users of ECOS data analysis are not CalHR IT, but instead staff who
 
 We’ve made the analysis-ready data tables produced by this project available to CalHR staff, who connect to them and have built dashboards using PowerBI. These dashboards provide self-service analytics to CalHR staff, allowing them to answer questions using the latest data that would have been slow and difficult to answer before. In the future, we hope to also allow state departments to access the same data to be able to better understand their own hiring processes.
 
-<img src="/papers/rose-hr-1/eac-fig-3.png" alt="Jobs and applications dashboard. It shows statistics like total jobs active, total applications received, and average applications received, including charts showing change over time." />
+![Jobs and applications dashboard. It shows statistics like total jobs active, total applications received, and average applications received, including charts showing change over time.](/papers/rose-hr-1/eac-fig-3.png)
 
 ## Impact
 

--- a/docs/pages/data/standard.md
+++ b/docs/pages/data/standard.md
@@ -29,7 +29,7 @@ Demographic and geographic data collection and analysis can be powerful tools fo
 
 ## Example
 
-<img src="/img/what-is-your-race-and-or-ethnicity.png" alt="An example of how to ask people about their race and ethnicity. It lists major categories with the opportunity to identify more specifically." />
+![An example of how to ask people about their race and ethnicity. It lists major categories with the opportunity to identify more specifically.](/img/what-is-your-race-and-or-ethnicity.png)
 
 ## Scope of responsibilities for State users
 

--- a/docs/pages/innovation-showcase.md
+++ b/docs/pages/innovation-showcase.md
@@ -3,7 +3,7 @@ title: Innovation Showcase
 description: An opportunity for California state teams to hear from innovators about challenges facing delivery of services to residents.
 ---
 
-<img src="/img/innovation-showcase.png" alt="Innovation Showcase, presented by the California Government Operations Agency and the Office of Data and Innovation" />
+![Innovation Showcase, presented by the California Government Operations Agency and the Office of Data and Innovation](/img/innovation-showcase.png)
 
 <p class="text-lead">The Government Operations Agency (GovOps) and the California Office of Data and Innovation (ODI) are launching the Innovation Showcase program. Government teams will get to hear from innovators about challenges facing delivery of services to residents. The Showcase will bridge the gap between the public and private sectors. It will start conversations about what’s possible through regular market research.</p>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
         "glob": "^7.2.0",
         "highlight.js": "^11.3.1",
         "html-to-text": "^9.0.5",
-        "markdown-it": "^13.0.1",
-        "markdown-it-anchor": "^8.6.4",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^9.2.0",
         "readability-scores": "^1.0.8",
         "showdown": "^2.1.0"
       },
@@ -170,6 +170,49 @@
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
       }
+    },
+    "node_modules/@11ty/eleventy/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@11ty/eleventy/node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/markdown-it": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
+      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "license": "MIT"
+    },
+    "node_modules/@11ty/eleventy/node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -5986,10 +6029,12 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "4.0.1",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/liquidjs": {
@@ -6150,21 +6195,26 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "13.0.1",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.js"
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "8.6.7",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.2.0.tgz",
+      "integrity": "sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==",
       "license": "Unlicense",
       "peerDependencies": {
         "@types/markdown-it": "*",
@@ -6174,6 +6224,18 @@
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/marky": {
       "version": "1.2.4",
@@ -6218,7 +6280,9 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "1.0.1",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
     },
     "node_modules/media-typer": {
@@ -7166,6 +7230,15 @@
     "node_modules/punycode": {
       "version": "2.1.1",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8612,7 +8685,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "glob": "^7.2.0",
     "highlight.js": "^11.3.1",
     "html-to-text": "^9.0.5",
-    "markdown-it": "^13.0.1",
-    "markdown-it-anchor": "^8.6.4",
+    "markdown-it": "^14.1.0",
+    "markdown-it-anchor": "^9.2.0",
     "readability-scores": "^1.0.8",
     "showdown": "^2.1.0"
   },


### PR DESCRIPTION
We've found that when a literal image tag &lt;img&gt; is followed by text, the markdown converter drops the paragraph break following the first paragraph (in some instances). 

This patch updates our markdown converter to the latest version.  This did not fix the problem.

It replaces the use of &lt;img&gt;  tags in several locations with markdown style image specifiers.  This does indeed fix the problem, although it is still technically a work-around.  

I believe the bug is in the 3rd party markdown-it converter.  It is likely suppressing forced paragraph breaks around html style tags, which is a mostly desirable behavior.  Unfortunately, markdown and html handle blank lines differently, so it's easy to confuse the parser.