### PR TITLE
Update links to plainlanguage.gov links

### DIFF
--- a/docs/pages/content-design/plain-language-checklist.md
+++ b/docs/pages/content-design/plain-language-checklist.md
@@ -18,7 +18,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/audience/">Written for easy reading by the average reader</a>
+                Written for easy reading by the average reader
             </div>
             <div class="checklist-tile-copy">
                     Measure reading level to make sure it’s not too high for your audience. Check this through <a href="https://hemingwayapp.com/">Hemingway</a>. Target is grade 8 or lower.
@@ -33,7 +33,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/organize/">Organized to serve the reader’s needs</a>
+                Organized to serve the reader’s needs
             </div>
             <div class="checklist-tile-copy">Content should be organized around what the reader wants to know and their potential next steps.
             </div>
@@ -43,7 +43,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/organize/add-useful-headings/">Has useful headings</a>
+                Has useful headings
             </div>
             <div class="checklist-tile-copy">Headings act as landmarks that help people understand what they are about to read, so make these as clear as possible. For example, including “Unemployment insurance benefits” in your heading makes it clear to claimants which benefits they are about to read about, which can be helpful if individuals have applied for multiple benefits.
             </div>
@@ -53,7 +53,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://readabilityguidelines.co.uk/grammar-points/capital-letters/">Uses sentence case, even in titles and headings</a>
+                Uses sentence case, even in titles and headings
             </div>
             <div class="checklist-tile-copy">Capitalize only proper nouns and the first word in sentences. This makes text easier to read and understand.
             </div>
@@ -63,7 +63,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/audience/address-the-user/">Uses “you” and other pronouns to speak to readers</a>
+                Uses “you” and other pronouns to speak to readers
             </div>
             <div class="checklist-tile-copy">Addressing the reader directly and using a human-centered tone helps readers understand what is relevant to them.
             </div>
@@ -73,10 +73,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                Uses
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/concise/write-short-sections/">short sections</a>
-                and
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/concise/write-short-sentences/">short sentences</a>
+                Uses short sections and short sentences
             </div>
             <div class="checklist-tile-copy">Overly complex sentences can be hard to parse. Review long sentences for core points and break them up into shorter sentences, grouping them by theme or timeline of events to increase clarity.
             </div>
@@ -86,7 +83,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/conversational/use-the-present-tense/">Uses the simplest tense possible</a>
+                Uses the simplest tense possible
             </div>
             <div class="checklist-tile-copy">Speak in the present tense. Simple present is best.
             </div>
@@ -96,7 +93,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/words/avoid-hidden-verbs/">Uses active voice, not hidden verbs</a>
+                Uses active voice, not hidden verbs
             </div>
             <div class="checklist-tile-copy">Use the strongest, most direct form of the verb possible. For example: “We scheduled a fact-finding interview” vs. “There was a fact-finding interview scheduled.”
             </div>
@@ -106,7 +103,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/concise/write-short-sentences/">Omits excessive words</a>
+                Omits excessive words<
             </div>
             <div class="checklist-tile-copy">Have one main idea per sentence.
             </div>
@@ -116,7 +113,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/words/use-simple-words-phrases/">Uses common, familiar words</a>
+                Uses common, familiar words
             </div>
             <div class="checklist-tile-copy">Avoid legalese, jargon, and figurative language.
             </div>
@@ -126,7 +123,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/words/place-words-carefully/">Places words carefully</a>
+                Places words carefully
             </div>
             <div class="checklist-tile-copy">Avoid large gaps between the subject, the verb, and the object. Put exceptions last. Place modifiers correctly.
             </div>
@@ -136,9 +133,7 @@ Adapted from the US Department of Labor’s [Use plain language for claimant not
         <div class="checklist-left-icon">&nbsp;</div>
         <div class="checklist-right-side">
             <div class="checklist-tile-header">
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/organize/use-lists/">Uses lists</a>
-                and 
-                <a class="external-link" href="https://www.plainlanguage.gov/guidelines/design/use-tables-to-make-complex-material-easier-to-understand/">tables</a> 
+                Uses lists and tables
                 to simplify complex material
             </div>
             <div class="checklist-tile-copy">When possible, provide information in lists, which are easier to process than large chunks of text. Tables can be used for more complex material.

--- a/docs/pages/content-design/principles.md
+++ b/docs/pages/content-design/principles.md
@@ -27,7 +27,7 @@ We were inspired by the work of teams that came before us, including:
 
 * 18F at the federal General Services Administration
 * [Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service) in the United Kingdom
-* The [Plain Language Action and Information Network](https://www.plainlanguage.gov/) at the US federal government
+* The Plain Language Action and Information Network at the US federal government
 * [Public Digital](https://public.digital/)
 * [San Francisco Digital Services](https://www.sf.gov/departments/city-administrator/digital-services)
 * [U.S. Digital Service](https://www.usds.gov/)

--- a/docs/pages/content-design/principles/be-concise.md
+++ b/docs/pages/content-design/principles/be-concise.md
@@ -52,7 +52,7 @@ Here’s an example of how to make content more concise:
   </div>
 </div>
 
-Plainlanguage.gov has more tips for [writing concise content](https://www.plainlanguage.gov/guidelines/concise/). You can also see examples of how to improve government writing.
+The federal government has more [tips for making writing short and simple](https://digital.gov/guides/plain-language/principles/short-simple). You can also see examples of how to improve government writing.
 
 <div class="leftright-nav-container">
     <div class="left-nav"><a class="internal-link" href="/content-design/principles/build-accessibility-from-start/">Build in accessibility from the start</a></div>

--- a/docs/pages/content-design/principles/focus-on-user-needs-services.md
+++ b/docs/pages/content-design/principles/focus-on-user-needs-services.md
@@ -38,7 +38,7 @@ Encourage your stakeholders to focus their content on requirements instead of re
 * Use **must** when telling people what they need to do.
 * Use **should** as little as possible and only for recommendations.
 * When stakeholders want to use **should**, ask them if people have to do something or if it’s a suggestion.
-* Learn more about [how to write about requirements at plainlanguage.gov](https://www.plainlanguage.gov/guidelines/conversational/use-must-to-indicate-requirements/).
+* Learn more about [how to write about requirements](https://digital.gov/guides/writing-understanding/familiar-terms#avoid-shall).
 
 <div class="leftright-nav-container">
     <div class="unused"></div>

--- a/docs/pages/content-design/principles/organize-content-strategically.md
+++ b/docs/pages/content-design/principles/organize-content-strategically.md
@@ -28,7 +28,7 @@ Arrange what your readers are looking for so they’re likely to see it.
   1. Begin with the content that is most important or affects the most people.
   2. Make the next most important or applicable content the next section.
   3. Repeat until you get to your last section of content. This should be the content that applies to the fewest number of people (like specific groups).
-* Headings are easy for readers to scan. Make your [headings useful](https://www.plainlanguage.gov/guidelines/organize/add-useful-headings/) so people understand what’s in that section.
+* Headings are easy for readers to scan. Make your [headings useful](https://digital.gov/guides/plain-language/design/headings) so people understand what’s in that section.
   * Use headings in descending order. Do not skip a level.
   * Use 3 levels of headings (H2, H3, and H4). If you find yourself using H5 or H6 headings, your organization may be too complex. Break up the content into multiple pages.
   * Only use one H1 per page for the title of the page.

--- a/docs/pages/content-design/principles/write-in-plain-language.md
+++ b/docs/pages/content-design/principles/write-in-plain-language.md
@@ -52,9 +52,9 @@ Check reading levels with the [Hemingway Editor](http://hemingwayapp.com/). Elim
   * If an acronym is better known to your audience than the full name (like CDC), use the acronym only. When in doubt, spell out the full name.
 * Tell people what they need to do instead of telling them what happens if they do not do something. It's easier for them to understand.
   * For example, write **You must apply by February 10** instead of **If you do not apply by February 10, your application will not be accepted**.
-  * One way to avoid this is by removing [double negatives](https://www.plainlanguage.gov/guidelines/concise/use-positive-language/).
-* Use [active voice](https://plainlanguage.gov/guidelines/conversational/use-active-voice/) and strong verbs.
-  * Do not use [hidden verbs](https://plainlanguage.gov/guidelines/words/avoid-hidden-verbs/).
+  * One way to avoid this is by removing [double negatives](https://digital.gov/guides/plain-language/writing/style#use-positive-language).
+* Use [active voice](https://digital.gov/guides/plain-language/writing#use-the-active-voice) and strong verbs.
+  * Do not use [hidden verbs](https://digital.gov/guides/plain-language/writing#avoid-hidden-verbs).
 * Do not use gerunds with **is** or **are**. A gerund is a verb that ends in -ing. 
 
 <div class="twocolumn-table">

--- a/docs/pages/content-design/recommended-reading.md
+++ b/docs/pages/content-design/recommended-reading.md
@@ -25,7 +25,7 @@ These are the style guides we look at when we have a new content question. We’
 
 * [Associated Press (AP) Style](https://store.stylebooks.com/) is ODI’s default for style questions not covered by [our style guide](/content-design/odi-style-guide/).
 * [How to write for SF.gov](https://sfdigitalservices.gitbook.io/style-guide/city-standards) (City of San Francisco)
-* [Federal plain language guidelines](https://www.plainlanguage.gov/guidelines/) at plainlanguage.gov (federal government)
+* [Plain Language Guide Series](https://digital.gov/guides/plain-language) (federal government)
 * Federal [style guides by government agencies](https://digital.gov/resources/style-guides-by-government-agencies/)
 * [Australian Government Style Manual](https://www.stylemanual.gov.au/)
 
@@ -56,7 +56,7 @@ Inclusive language uses words that respect all people. ODI doesn’t maintain ou
 
 ### Plain language
 
-[Plainlanguage.gov](https://www.plainlanguage.gov/) is a great resource for how to use plain language. It’s maintained by the US federal government. Their site also includes [examples of plain language](https://www.plainlanguage.gov/examples/) in action.
+The federal [Plain Language Guide Series](https://digital.gov/guides/plain-language) is a great resource for how to use plain language. It’s maintained by the US federal government.
 
 The [ClearMark Awards](https://centerforplainlanguage.org/awards/clearmark/) honor the best plain language communications. They’re a great place to find inspiration for your writing. Winners come from government, nonprofit, and business.
 
@@ -64,7 +64,7 @@ The [ClearMark Awards](https://centerforplainlanguage.org/awards/clearmark/) hon
 
 Swapping complex words for simple ones is a big part of plain language. These word substitution lists can help with that.
 
-* Start with [Plainlanguage.gov’s Use simple words and phrases](https://www.plainlanguage.gov/guidelines/words/use-simple-words-phrases/). It covers the most common words.
+* Start with [Plainlanguage.gov’s Use simple words and phrases](https://web.archive.org/web/20250919222219/https://www.plainlanguage.gov/guidelines/words/use-simple-words-phrases/) on the Internet Archive. It covers the most common words.
 * [Health Research for Action at UC Berkeley's Plain Language Word List](https://multco-web7-psh-files-usw2.s3-us-west-2.amazonaws.com/s3fs-public/PlainLanguageWordList.pdf) has lots of healthcare-specific words.
 * The most complete list is the [Plain English Lexicon](https://clearest.co.uk/wp-content/uploads/2021/09/Plain_English_LEXICON_June_2011.pdf). It has 2,700 words. However, some are specific to British English.
 


### PR DESCRIPTION
Update pages in the content design section to remove or update links to plainlanguage.gov, which has been replaced with a new federal government resource.