### PR TITLE
Modified deploy scripts for security.

### DIFF
--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -44,7 +44,8 @@ jobs:
         run: |
           mkdir _site
           mkdir _site_dist
-          npm install --legacy-peer-deps
+          # using npm ci instead of npm install to reduce threat of installing newer packages than intended
+          npm ci
           DOMAIN=${URLSAFE_BRANCH_NAME}.pr.hub.innovation.ca.gov npm run build
           npm run readability
           DOMAIN=${URLSAFE_BRANCH_NAME}.pr.hub.innovation.ca.gov npm run build

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Build Site
         run: |
-          npm install
+          # using npm ci instead of npm install to reduce threat of installing newer packages than intended
+          npm ci
           npm run build
           npm run readability
           npm run build


### PR DESCRIPTION
Modified deploy scripts to use npm ci instead of npm install.

This is to prevent accidental installation of a package version later than the one currently used in package-lock.json, which is an avenue thru which compromised packages can be installed.