### PR TITLE
Fix CodeQL alerts: useless regex escape, missing workflow permissions

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -11,6 +11,9 @@ concurrency: # replaces use of n1hility/cancel-previous-runs
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build_deploy:
     runs-on: ubuntu-latest

--- a/docs/site/search.njk
+++ b/docs/site/search.njk
@@ -98,7 +98,7 @@ eleventyExcludeFromCollections: true
 		.insertBefore(gcse, s[s.length - 1]);
 
 	const urlParam = function (name) {
-		var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.search);
+		var results = new RegExp('[?&]' + name + '=([^&#]*)').exec(window.location.search);
 
 		return (results !== null)
 			? results[1] || 0


### PR DESCRIPTION
## Summary
Fixes both open CodeQL alerts:

1. **`js/useless-regexp-character-escape` (high) — `docs/site/search.njk`:** The `urlParam` helper built a RegExp from the string `'[\?&]'`. In a JavaScript string literal, `'\?'` is identical to `'?'`, so the escape never reached the regex engine — and inside a character class `?` is a literal anyway. Removed the escape; runtime behavior is byte-for-byte identical (verified the built search page).

2. **`actions/missing-workflow-permissions` (medium) — `.github/workflows/deploy_prod.yml`:** Added an explicit top-level `permissions: contents: read` block so the `GITHUB_TOKEN` is no longer granted the default write-all permissions. The workflow only needs to check out code — the S3/CloudFront deploy authenticates via repository secrets, not the token. (`deploy_pr_preview.yml` already had a permissions block.)

## Testing
- `npm run build` passes; the corrected regex appears in `_site/search/index.html`
- Workflow change is config-only and takes effect on the next push to main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)