### PR TITLE
Bump js-yaml to 3.15.0 to fix DoS alert (#27)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4803,9 +4803,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
## Summary
Resolves Dependabot alert #27 (medium): **js-yaml quadratic-complexity DoS in merge-key handling via repeated aliases** (`< 3.15.0`).

The vulnerable copy was the transitive `js-yaml@3.14.2` at the lockfile root, pulled in by `gray-matter`, `eslint`, and `@eslint/eslintrc`. This bumps it to **3.15.0**, which satisfies their existing `^3.13.1` constraints — so this is a **lockfile-only** change and `package.json` is untouched.

This manually applies the fix that Dependabot's own automated update [could not generate](https://github.com/cagov/hub.innovation.ca.gov/network/updates/1439717539) — that run failed with an updater container error, not a code/CI failure.

## Verification
- `npm ci` succeeds (lockfile consistent with package.json)
- `npm run build` (eleventy) succeeds — 51 files written, no errors
- `npm audit` shows no remaining js-yaml findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)