### PR TITLE
CalLearns 2026-27 link updates

### DIFF
--- a/docs/pages/content-design/building-better-services-plain-language.md
+++ b/docs/pages/content-design/building-better-services-plain-language.md
@@ -20,4 +20,4 @@ The course includes time to practice writing in plain language. You will be able
 
 Before taking this course, take [Introduction to plain language for the public sector](/content-design/introduction-plain-language-public-sector/). This can have been with an instructor or the self-paced online course. The ODI-hosted webinar alone is not enough.
 
-[Sign up for the course on CalLearns.](https://calhr.geniussis.com/Registration.aspx?AID=5281) The course is free. You need a CalLearns account to register for the training.
+[Sign up for the course on CalLearns.](https://calhr.geniussis.com/Registration.aspx?AID=6295) The course is free. You need a CalLearns account to register for the training.

--- a/docs/pages/content-design/introduction-plain-language-public-sector.md
+++ b/docs/pages/content-design/introduction-plain-language-public-sector.md
@@ -19,4 +19,4 @@ You’ll learn:
 
 The course includes opportunities to practice writing in plain language. You will be able to start using the skills you learn immediately.
 
-[Sign up for the course on CalLearns.](https://calhr.geniussis.com/Registration.aspx?AID=5289) The course is free. You need a CalLearns account to register for the training.
+[Sign up for the course on CalLearns.](https://calhr.geniussis.com/Registration.aspx?AID=6294) The course is free. You need a CalLearns account to register for the training.

--- a/docs/pages/product-management/introduction-product-approach-public-sector.md
+++ b/docs/pages/product-management/introduction-product-approach-public-sector.md
@@ -16,4 +16,4 @@ You’ll learn how to:
 * Deliver early and often
 * Measure success and optimize for outcomes 
 
-[Sign up for the course on CalLearns](https://calhr.geniussis.com/Registration.aspx?AID=5288). You need a CalLearns account to register for the training.
+[Sign up for the course on CalLearns](https://calhr.geniussis.com/Registration.aspx?AID=6296). You need a CalLearns account to register for the training.


### PR DESCRIPTION
Updated links to CalLearns courses in:

- Introduction to plain language for the public sector
- Building better services with plain language
- Introduction to a product approach for the public sector

Updated title to match CalLearns for _Introduction to a product approach for the public sector_.