### PR TITLE
Copy docs/src/assets/docs into build (fix 404s for BUCP & IDEA agreement)

### DIFF
--- a/docs/pages/data/idea-guidebook/resources-references/bucp-template.md
+++ b/docs/pages/data/idea-guidebook/resources-references/bucp-template.md
@@ -17,7 +17,7 @@ headericon: book
 Use this Word document to draft your BUCPs. There are two versions: use the first if there is only one Data Provider and Data Recipient. Use the second if there are multiple Data Providers or Data Recipients. If needed, we will periodically update this based on feedback and include version notes.
 
 * [BUCP template V2 for single department](/docs/bucp-template-v2-single-dept.docx) 
-* [BUCP template V2 for single department](/docs/bucp-template-v2-multiple-dept.docx)
+* [BUCP template V2 for multiple departments](/docs/bucp-template-v2-multiple-dept.docx)
 
 <div class="callout-info">
   <p>Remember when you complete your BUCP to <a href="https://airtable.com/shrUMjZghIK1aAQqR">submit to the Statewide Chief Data Officer</a>.</p>

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -135,6 +135,7 @@ export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ 'docs/src/assets/img': 'img' });
  //  eleventyConfig.addPassthroughCopy({ 'docs/src/assets/article-content': 'content/img' });
   eleventyConfig.addPassthroughCopy({ 'docs/src/assets/papers': 'papers' });
+  eleventyConfig.addPassthroughCopy({ 'docs/src/assets/docs': 'docs' });
   eleventyConfig.addPassthroughCopy({ 'docs/src/css/fonts': 'fonts' });
   eleventyConfig.addPassthroughCopy({ '_site_dist/*': '/' });
   eleventyConfig.addPassthroughCopy({ 'docs/src/assets/papers/bobra-water-1': 'papers/bobra-water-1' });


### PR DESCRIPTION
## Summary
- The BUCP Word templates and the IDEA agreement PDF live in `docs/src/assets/docs/` and are linked from the guidebook (e.g. `/docs/bucp-template-v2-single-dept.docx`, `/docs/idea-agreement-2021.pdf`), but that directory had **no Eleventy passthrough**, so the files were never emitted to `_site` on a clean build — resulting in 404s in production.
- Add `eleventyConfig.addPassthroughCopy({ 'docs/src/assets/docs': 'docs' })` so all three tracked assets are copied to `/docs` in the build.
- Fix a duplicate link label on the BUCP templates page: the second link now reads "for multiple departments" instead of repeating "single department".

## Why they appeared to work locally
Locally the files existed in `_site/docs/` only as stale artifacts from an older build (Eleventy doesn't clean its output dir). CI builds from a fresh checkout and deploys to S3 with `--delete`, so the missing passthrough meant the files were absent in production.

## Verification
- Reproduced production 404: `https://hub.innovation.ca.gov/docs/idea-agreement-2021.pdf` -> 404.
- With the fix on the local dev server, all links resolve:
  - `/docs/bucp-template-v2-single-dept.docx` -> 200 (Word MIME type)
  - `/docs/bucp-template-v2-multiple-dept.docx` -> 200 (Word MIME type)
  - `/docs/idea-agreement-2021.pdf` -> 200 (application/pdf)

## Test plan
- [ ] Deploy preview builds successfully
- [ ] On the preview, the three links above return 200 (not 404)
- [ ] BUCP templates page shows two distinctly-labeled links

Made with [Cursor](https://cursor.com)