### PR TITLE
Fix broken links found in site crawl (font preload, image typo, stray component pages)

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -8,3 +8,4 @@ README.md
 node_modules/**
 **/node_modules/**
 _site_dist
+docs/src/js

--- a/docs/pages/data/developing-trustworthy-monitoring-data.md
+++ b/docs/pages/data/developing-trustworthy-monitoring-data.md
@@ -14,7 +14,7 @@ Monica G. Bobra <a href="https://orcid.org/0000-0002-5662-9604"><img class="orci
 
 <div class="interaction-block">
 <div class="interaction"><a href="/papers/bobra-et-al-developing-trustworthy-monitoring-data.pdf"><img class="icon" src="/img/paper-pdf-icon.svg" /> Download PDF</a></div>
-<div class="interaction"><a href="https://doi.org/10.5281/zenodo.19579174"><img class="icon" src="/img/paper-ink-icon.svg" />https://doi.org/10.5281/zenodo.19579174</a></div>
+<div class="interaction"><a href="https://doi.org/10.5281/zenodo.19579174"><img class="icon" src="/img/paper-link-icon.svg" />https://doi.org/10.5281/zenodo.19579174</a></div>
 </div>
 
 ## The opportunity

--- a/docs/site/_includes/layouts/index.njk
+++ b/docs/site/_includes/layouts/index.njk
@@ -4,7 +4,6 @@
   <title>{{ metadata.page_title }}</title> 
   <link rel="preload" href="/fonts/publicsans-bold-webfont.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preload" href="/fonts/publicsans-regular-webfont.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="/fonts/CaGov.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif:wght@700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
A crawl of the site (174 pages) surfaced three internal issues, fixed here:

1. **Font preload 404 on every page** — the base layout preloaded `/fonts/CaGov.woff2`, which doesn't exist in the repo (no file, and no `@font-face` references it). Removed the preload.
2. **Broken image** on the "Developing trustworthy monitoring data" page — `/img/paper-ink-icon.svg` (nonexistent) corrected to `/img/paper-link-icon.svg` (an existing icon; fits the DOI link).
3. **Stray component pages** — markdown under `docs/src/js/` (e.g. the airtable-form `CHANGELOG.md`/`README.md`) was being published as Eleventy pages (`/CHANGELOG/`, etc.) with a broken `<link rel="canonical" href="/undefined">`. Added `docs/src/js` to `.eleventyignore`.

## Verification
- Local dev server confirms the image fix: `/img/paper-link-icon.svg` -> 200 and the page now references it.
- The font-preload and `.eleventyignore` changes are verified at the source (templates no longer reference `CaGov.woff2`); they take full effect on a clean build since Eleventy's incremental dev server keeps serving stale `_site` files.

## Notes / out of scope
- Several **external** links also 404 (CA Design System docs that moved, plus a few others) — left out of this PR since they need replacement-URL decisions. Happy to follow up.
- One par-statistics table entry (`/content-design/more-plain-language-public-sector/`) 404s because it comes from the remote performance-audit API's stale data, not this repo.

## Test plan
- [ ] Deploy preview builds successfully
- [ ] Preview homepage no longer requests `/fonts/CaGov.woff2` (no 404 in network tab)
- [ ] `/data/developing-trustworthy-monitoring-data/` shows the link icon (no broken image)
- [ ] `/CHANGELOG/` (and other `docs/src/js` component docs) return 404 / are not generated

Made with [Cursor](https://cursor.com)