### PR TITLE
Bump js-yaml to 4.3.0 and brace-expansion to 1.1.16 (Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -2360,9 +2360,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
## Summary

Resolves the two open Dependabot alerts, both high severity, both transitive dependencies that Dependabot could not auto-resolve:

- **js-yaml** 4.2.0 → **4.3.0** — [YAML merge-key chains can force quadratic CPU consumption](https://github.com/cagov/hub.innovation.ca.gov/security/dependabot/32) (pulled in by `@11ty/eleventy`)
- **brace-expansion** 1.1.13 → **1.1.16** — [DoS via exponential-time expansion of consecutive non-expanding {} groups](https://github.com/cagov/hub.innovation.ca.gov/security/dependabot/31) (pulled in by `eslint` → `minimatch`)

Both are semver-compatible patch bumps of transitive dependencies, so the change is `package-lock.json` only — no `package.json` changes.

## Verification

- `npm audit` no longer reports either advisory (one unrelated moderate advisory remains for `showdown`, which has no fixed version available)
- `npm ci && npm run build` succeeds with the updated lockfile (57 files written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)