### PR TITLE
Bump js-yaml to patched versions (3.15.1, 4.3.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@11ty/eleventy/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -4803,9 +4803,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
## What happened

The [Dependabot Updates run](https://github.com/cagov/hub.innovation.ca.gov/actions/runs/31746461672/job/94602085432) failed while trying to open a security PR for a `js-yaml` advisory. It reported conflicting dependencies:

- `eslint@7.32.0`, `@eslint/eslintrc`, and `gray-matter` require `js-yaml@^3.13.1`
- `@11ty/eleventy@3.1.6` requires `js-yaml@^4.1.1`

Dependabot tries to land a single non-vulnerable version, and no one version satisfies both a 3.x and a 4.x range — so the updater errored rather than performing two separate bumps.

## Fix

Both patched releases (`3.15.1`, `4.3.1`) already fall inside the existing semver ranges, so no `overrides` entry is needed — this is a lockfile-only refresh via `npm update js-yaml`:

| Consumer | Before | After |
| --- | --- | --- |
| eslint, @eslint/eslintrc, gray-matter | 3.15.0 | 3.15.1 |
| @11ty/eleventy | 4.3.0 | 4.3.1 |

## Verification

- `npm run build` succeeds — 199 files copied, 59 written, no errors
- `npm audit` no longer reports js-yaml

## Not covered here

- **brace-expansion** (high) — already has PR #159 open
- **showdown** (moderate, XSS/ReDoS) — no upstream fix available; would require replacing the dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)